### PR TITLE
feat: adding GH action to publish to nuget.org

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,62 @@
+name: Publish to NuGet.org
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.gitversion.outputs.fullSemVer }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup NuGet authentication
+      uses: actions/setup-dotnet@v2
+      with:
+        source-url: https://nuget.pkg.github.com/biosero/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.15
+      with:
+        versionSpec: '5.x'
+
+    - name: GitVersion
+      id: gitversion
+      uses: gittools/actions/gitversion/execute@v0.9.15
+      with:
+        useConfigFile: true
+        additionalArguments: -updateprojectfiles
+
+    - name: Build
+      run: dotnet build Biosero.Orchestrator.DevTools.sln --configuration ${{ env.BUILD_CONFIGURATION }}
+
+    - name: Test
+      run: dotnet test Biosero.Orchestrator.DevTools.sln --no-build --configuration ${{ env.BUILD_CONFIGURATION }}
+
+    - name: Package
+      run: dotnet pack src/Biosero.Orchestrator.ScriptingTools/Biosero.Orchestrator.ScriptingTools.csproj --no-build --configuration ${{ env.BUILD_CONFIGURATION }} -p:PackageVersion=${{ steps.gitversion.outputs.fullSemVer }}
+
+    - name: Publish
+      run: dotnet nuget push src/Biosero.Orchestrator.ScriptingTools/bin/${{ env.BUILD_CONFIGURATION }}/Biosero.Orchestrator.ScriptingTools.${{ steps.gitversion.outputs.fullSemVer }}.nupkg --api-key ${{ secrets.NUGET_ORG_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Archive
+      uses: actions/upload-artifact@v3
+      with:
+        name: Biosero.Orchestrator.ScriptingTools.${{ steps.gitversion.outputs.fullSemVer }}.nupkg
+        path: src/Biosero.Orchestrator.ScriptingTools/bin/${{ env.BUILD_CONFIGURATION }}/Biosero.Orchestrator.ScriptingTools.${{ steps.gitversion.outputs.fullSemVer }}.nupkg
+        retention-days: 5

--- a/Biosero.Orchestrator.DevTools.sln
+++ b/Biosero.Orchestrator.DevTools.sln
@@ -27,6 +27,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E17EB1F8-437E-4365-9E30-F2ED0868E6F8}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\codeql.yml = .github\workflows\codeql.yml
+		.github\workflows\nuget.yml = .github\workflows\nuget.yml
 		.github\workflows\package.yml = .github\workflows\package.yml
 	EndProjectSection
 EndProject

--- a/README.md
+++ b/README.md
@@ -8,26 +8,7 @@ The Scripting Tools package is designed to improve the developer experience when
 
 ### Getting started
 
-Biosero Orchestrator Scripting Tools is installed via NuGet from Biosero's private GitHub packages feed.  You will need to add this feed as a package source.  Full documentation on how to authenticate to a GitHub feed can be found [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#authenticating-with-a-personal-access-token).  The easiest way to do this locally on Windows is to find the _C:\Users\YOUR_WINDOWS_USERNAME\AppData\Roaming\NuGet\Nuget.Config_ file, and add the source and credentials there.
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <!-- other sources here like nuget.org -->
-
-        <add key="github-biosero" value="https://nuget.pkg.github.com/biosero/index.json" />
-    </packageSources>
-    <packageSourceCredentials>
-        <github-biosero>
-            <add key="Username" value="YOUR_GITHUB_USERNAME" />
-            <add key="ClearTextPassword" value="YOUR_GITHUB_PERSONAL_ACCESS_TOKEN" />
-        </github-biosero>
-    </packageSourceCredentials>
-</configuration>
-```
-
-Once the Biosero GitHub package source is successfully installed, you should be able to add the Scripting Tools package to any .NET project.
+Biosero Orchestrator Scripting Tools is installed via NuGet from the nuget.org package feed.
 
 ```
 dotnet add package Biosero.Orchestrator.ScriptingTools


### PR DESCRIPTION
1. Adding GH action to publish Biosero.Orchestrator.ScriptingTools nuget package to nuget.org.  The action must be manually triggered.  Figured this is the safest way until we are comfortable with release workflow for this repo.
2. Removed README section on authenticating to private feed.