### PR TITLE
fix: example project package reference to pull from nuget.org

### DIFF
--- a/examples/Scripting/Acme.Orchestrator.Scripting/Acme.Orchestrator.Scripting.csproj
+++ b/examples/Scripting/Acme.Orchestrator.Scripting/Acme.Orchestrator.Scripting.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Biosero.Orchestrator.ScriptingTools" Version="1.3.1" />
+		<PackageReference Include="Biosero.Orchestrator.ScriptingTools" Version="1.3.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />

--- a/src/Biosero.Orchestrator.ScriptingTools/Biosero.Orchestrator.ScriptingTools.csproj
+++ b/src/Biosero.Orchestrator.ScriptingTools/Biosero.Orchestrator.ScriptingTools.csproj
@@ -16,6 +16,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Westwind.Scripting" Version="1.3.3" />


### PR DESCRIPTION
1. Fix package reference to pull a version from nuget.org instead of GitHub packages
2. Add SourceLink