### PR TITLE
fix: GitVersion building of tags and update README

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -9,13 +9,13 @@ branches:
     tracks-release-branches: true
     pre-release-weight: 0
     prevent-increment:
-      when-current-commit-tagged: false
+      when-current-commit-tagged: true
   release:
     mode: ContinuousDelivery
     increment: Patch
     label: rc
     prevent-increment:
-      when-current-commit-tagged: false
+      when-current-commit-tagged: true
   pull-request:
     is-release-branch: false
     tracks-release-branches: false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ namespace Acme.Orchestrator.Scripting
 }
 ```
 
-The `DataServicesClient` class is a strongly typed HTTP client for the Data Services API.  The actual class is auto generated from our Open API (Swagger) documentation.  A mock version of the class exists in the Scripting Tools package.  The mock version is an abstract class with all abstract methods that mirror the signatures of the actual version.  This allows a matching contract while easily enabling the mocking of the abstract methods with unit testing tools like [Moq](https://github.com/moq/moq).
+The `DataServicesClient` class is a strongly typed HTTP client for the Data Services API.  The class is pulled in from the `Biosero.DataServices.Client` NuGet package.  All methods are virtual which enables the mocking of the methods with unit testing tools like [Moq](https://github.com/moq/moq).
 
 ```csharp
 var client = new Mock<DataServicesClient>().Object;

--- a/src/Biosero.Orchestrator.ScriptingTools/Biosero.Orchestrator.ScriptingTools.csproj
+++ b/src/Biosero.Orchestrator.ScriptingTools/Biosero.Orchestrator.ScriptingTools.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Authors>Biosero Services Team</Authors>
 		<Company>Biosero Inc</Company>
-		<Description>A library containing mock dependencies for Orchestrator Workflow scripts.</Description>
+		<Description>A library containing development dependencies for Orchestrator Workflow scripts.</Description>
 		<Copyright>Copyright © 2024 Biosero Inc</Copyright>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/biosero/orchestrator-devtools</PackageProjectUrl>
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Biosero.DataServices.Client" Version="1.6.1" />
+		<PackageReference Include="Biosero.DataServices.Client" Version="1.6.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
When releasing by ScriptingTools nuget package recently, I was getting some weird results from GitVersion when building a specific tag from a GH action that weren't reproducible locally.  To work around the weird behavior, I turned off incrementing the version number when branch is tagged.  I'll have to make similar updates to our other Orchestrator repos.

Update README.