### PR TITLE
fix: Package CI gh action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Setup DotNet
         uses: actions/setup-dotnet@v4
         with:
-          global-json-file: global.json
           source-url: https://nuget.pkg.github.com/biosero/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix Package CI gh action step by removing global.json requirement from package push job.  We don't need a specific .net SDK to simply push a package anyway.